### PR TITLE
Improve compare face flow

### DIFF
--- a/src/app/modules/auth/smart-enroll/smart-biometrics/smart-biometrics.component.ts
+++ b/src/app/modules/auth/smart-enroll/smart-biometrics/smart-biometrics.component.ts
@@ -68,27 +68,18 @@ export class SmartBiometricsComponent implements OnDestroy {
 
                 this._smartEnrollService.setLivenessScore(response.data.biometricValidation.livenessScore);
 
-                if (this.appRegistration.documentValidation && this.appRegistration.biometricValidation) {
-                    this._KYCService.compareFaces().subscribe({
-                        next: (response) => {
-                            this.appRegistration.compareFaceVerification = response.data.compareFaceVerification;
+                this._KYCService.compareFaces().subscribe({
+                    next: (response) => {
+                        this.appRegistration.compareFaceVerification = response.data.compareFaceVerification;
 
-                            this._smartEnrollService.setCompareScore(response.data.compareFaceVerification.result.score);
-                        },
-                        error: (error) => this._handleError(error),
-                        complete: () => {
-                            this._syncAppRegistration("end", "ONGOING");
-                            this.successfulUploadSubject.next();
-                            this._smartEnrollService.goToNextStep();
-                        },
-                    });
+                        this._smartEnrollService.setCompareScore(response.data.compareFaceVerification.result.score);
 
-                    return;
-                }
-
-                this._syncAppRegistration("end", "ONGOING");
-                this._smartEnrollService.goToNextStep();
-                this.successfulUploadSubject.next();
+                        this._syncAppRegistration("end", "ONGOING");
+                        this.successfulUploadSubject.next();
+                        this._smartEnrollService.goToNextStep();
+                    },
+                    error: (error) => this._handleError(error),
+                });
             },
             error: (error) => this._handleError(error),
         });

--- a/src/app/modules/auth/smart-enroll/smart-documents/smart-documents.component.ts
+++ b/src/app/modules/auth/smart-enroll/smart-documents/smart-documents.component.ts
@@ -268,11 +268,17 @@ export class SmartDocumentsComponent implements OnDestroy {
         }
 
         const settings = this.projectFlow.onboardingSettings.document;
+
         const observables$ = {
+            compareValidation: null,
             criminalValidation: null,
             nameValidation: null,
-            compareValidation: null,
         };
+
+        observables$.compareValidation = this._KYCService.compareFaces().pipe(
+            map((result) => ({ status: "fulfilled", data: result.data })),
+            catchError((error) => of({ status: "rejected", reason: error }))
+        );
 
         if (settings.verifyNames) {
             const payload = {
@@ -321,25 +327,12 @@ export class SmartDocumentsComponent implements OnDestroy {
             });
         }
 
-        if (this.appRegistration.biometricValidation) {
-            const observable$ = this._KYCService.compareFaces().pipe(
-                map((result) => ({ status: "fulfilled", data: result.data })),
-                catchError((error) => of({ status: "rejected", reason: error }))
-            );
-
-            observables$.compareValidation = observable$;
-        } else {
-            observables$.compareValidation = Promise.resolve({
-                status: "NA",
-                data: {},
-            });
-        }
-
         forkJoin(observables$).subscribe({
             next: (results: CombinedValidationResponse) => {
                 if (results.criminalValidation?.status === "rejected") {
                     if (results.criminalValidation?.error?.code === "PaymentRequired") {
                         this._smartEnrollService.insufficientCreditsTrigger();
+
                         return;
                     }
 


### PR DESCRIPTION
Remove assertion before `compareFace` and instead, run the request - The backend now has protections to not run `compareFace` unnecessarily - meaning we use the DB rather than the frontend state to confirm the status against.